### PR TITLE
Only match the first colon for tags to allow URLs in tag data

### DIFF
--- a/core.py
+++ b/core.py
@@ -41,7 +41,7 @@ class MKVTagger(object):
                 print()
                 for tag_line in t:
                     tag_line = tag_line.strip()
-                    tag_name = tag_line.split(':')
+                    tag_name = tag_line.split(':', 1)
 
                     tag_value = self.__process_value(
                         tag_name[1].strip()


### PR DESCRIPTION
Addresses https://github.com/dropcreations/mkvtagger/issues/2 by only matching the first colon for tag name.
